### PR TITLE
Fix distance calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,8 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
-test/data/berlin-latest*
-test/data/car.lua
-test/data/lib/access.lua
+test/data/
+!test/data/Makefile
 stxxl.errlog
 
 # Dependency directory
@@ -31,3 +30,4 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -85,4 +85,3 @@ isochrone.draw = function(destinations) {
 }
 isochrone.getIsochrone();
 ```
-

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function (center, time, options, done) {
         // this will account for a driver going a bit above the max safe speed
         var centerPt = point(center);
         var spokes = featureCollection([]);
-        var length = (time/3600) * options.maxspeed;
+        var length = options.distance ? time/1000 : (time/3600) * options.maxspeed;
         spokes.features.push(destination(centerPt, length, 180, unit));
         spokes.features.push(destination(centerPt, length, 0, unit));
         spokes.features.push(destination(centerPt, length, 90, unit));

--- a/test/data/data.md5sum
+++ b/test/data/data.md5sum
@@ -1,2 +1,0 @@
-833f482fc35f34b0cc2a82db57fd519f  car.lua
-045af81d07eb9f22e5718db13cf337e4  berlin-latest.osm.pbf

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ test('osrm-isochrone', function(t) {
       resolution: 25, // sample resolution
       maxspeed: 70, // in 'unit'/hour
       unit: 'miles', // 'miles' or 'kilometers'
-      network: 'test/data/berlin-latest.osrm' // prebuild dc osrm network file
+      network: './test/data/berlin-latest.osrm' // prebuild dc osrm network file
     }
     var center = [13.388860,52.517037]; // center point
     var time = 300; // 300 second drivetime (5 minutes)


### PR DESCRIPTION
This PR fixes distance calculation.

For example on a 1km from 42.5330, 1.5672 (Andorra), we go from a 5.13s request giving a shape of 35 pts to a 4.9s giving a shape of 279 pts.

On a  1km from 44.8340, 1.56721 (Bordeaux), we go from a 5.9s request giving a shape of 37 pts to a 1.52s request giving a shape of 579 pts.
